### PR TITLE
Revert "Japanese Text Only"

### DIFF
--- a/2020年8月1３日 - 手を洗う事ができない
+++ b/2020年8月1３日 - 手を洗う事ができない
@@ -1,23 +1,35 @@
 URL: https://www3.nhk.or.jp/news/easy/k10012564861000/k10012564861000.html
 
 ２０２０年８月13日
+13 Aug 2020
 
 手を洗う事ができない
+Can't Wash Hands
 
 世界の４３％の学校で手を洗う事ができない
+43% of schools all over the world do not have a place for students to wash their hands
 
 ウイルスが心配
+This causes uneasiness regarding the virus
 
 ウニセフとWHOによると、世界では去年、手をせっけんで洗う事ができない学校が４３％ありました。
+According to UNICEF and WHO, there are 43% of schools that can't provide soaps
+for students to wash their hands with all over the world.
 
 このため、８億１８００万人の子供は新しいコロナウイルスなどがうつる心配があります。
+Because of this, 818 million children are in danger of contracting the new Corona Virus.
 
 この中の３０％以上の２億９５００万人はアフリカの子供です。
+30% of this comprise of 295 million African children.
 
 ユネスコによると、今月２日には１０６国と地域で学校が休みになっています。
+According to UNESCO, on August 2, 106 countries have closed down schoolgrounds.
 
 世界の学生の６０.５％の１０億人が学校に行く事ができなくなっています。
+Globally, 60.5% comprising of 1 billion students are unable to go to school.
 
 ユニセフの人は「子供達が学校で安全に勉強できるように、
+As stated by a UNICEF spokesperson, "In order for kids to study safely at school,
 
 手を洗う場所や読む事ができるきれいな水用意しなければなりません」と言っています。
+there should be a place for students to wash their hands and have access to clean drinking water.


### PR DESCRIPTION
Reverts Macolette/NHK-Web-Easy-News#3

branch containing both Japanese and English overwritten. Need to revert.